### PR TITLE
fix changes in latest asyncio connect() method

### DIFF
--- a/elmax_api/push/push.py
+++ b/elmax_api/push/push.py
@@ -87,9 +87,17 @@ class PushNotificationHandler:
 
     async def _connect(self):
         token = await self._client.login()
-        return await websockets.connect(self._endpoint, ssl=self._ssl_context, extra_headers={
-            "Authorization": self._client._raw_jwt
-        })
+        index = self._endpoint.find('https')
+        if index == -1:
+            return await websockets.connect(self._endpoint, ssl=None, additional_headers={
+                "Authorization": self._client._raw_jwt
+            })
+        else:
+            return await websockets.connect(self._endpoint, ssl=self._ssl_context, additional_headers={
+                "Authorization": self._client._raw_jwt
+            })
+
+
 
     async def _notify_handlers(self, message):
         _LOGGER.debug("Handling message dispatching for handlers")


### PR DESCRIPTION
previous version gives this error for HTTP connections:

`Error occurred when handling websocket connection. We will re-establish the connection in 15 seconds.
Traceback (most recent call last):
  File "/Users/fabio/PycharmProjects/elmax-api/elmax_api/push/push.py", line 124, in _looper
    connection = await self._connect()
  File "/Users/fabio/PycharmProjects/elmax-api/elmax_api/push/push.py", line 90, in _connect
    return await websockets.connect(self._endpoint, ssl=self._ssl_context, extra_headers={
  File "/Users/fabio/PycharmProjects/elmax-api/.venv/lib/python3.9/site-packages/websockets/asyncio/client.py", line 442, in __await_impl__
    self.connection = await self.create_connection()
  File "/Users/fabio/PycharmProjects/elmax-api/.venv/lib/python3.9/site-packages/websockets/asyncio/client.py", line 360, in create_connection
    raise ValueError("ssl argument is incompatible with a ws:// URI")
ValueError: ssl argument is incompatible with a ws:// URI`

and this for HTTPS connections:

`Error occurred when handling websocket connection. We will re-establish the connection in 15 seconds.
Traceback (most recent call last):
  File "/Users/fabio/PycharmProjects/elmax-api/elmax_api/push/push.py", line 124, in _looper
    connection = await self._connect()
  File "/Users/fabio/PycharmProjects/elmax-api/elmax_api/push/push.py", line 90, in _connect
    return await websockets.connect(self._endpoint, ssl=self._ssl_context, extra_headers={
  File "/Users/fabio/PycharmProjects/elmax-api/.venv/lib/python3.9/site-packages/websockets/asyncio/client.py", line 442, in __await_impl__
    self.connection = await self.create_connection()
  File "/Users/fabio/PycharmProjects/elmax-api/.venv/lib/python3.9/site-packages/websockets/asyncio/client.py", line 368, in create_connection
    _, connection = await loop.create_connection(factory, **kwargs)
TypeError: create_connection() got an unexpected keyword argument 'extra_headers'`